### PR TITLE
Fix engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/florianeckerstorfer/gatsby-plugin-advanced-feed.git"
   },
   "engines": {
-    "node": ">=14.0.0,<17.0.0"
+    "node": ">=14.0.0 <17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.16.0",


### PR DESCRIPTION
Hello! Thank you for this plugin!
I installed it to my project and got an error : `error @fec/gatsby-plugin-advanced-feed@3.0.0: The engine "node" is incompatible with this module. Expected version ">=14.0.0,<17.0.0". Got "16.16.0"`, seems like it's just a syntax typo because multiple engines.node should be divided with a space