### PR TITLE
Upgrade engines - support node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/florianeckerstorfer/gatsby-plugin-advanced-feed.git"
   },
   "engines": {
-    "node": ">=14.0.0 <17.0.0"
+    "node": ">=16.0.0 <19.0.0"
   },
   "dependencies": {
     "dayjs": "^1.10.7",


### PR DESCRIPTION
:wave:

Hello! When upgrading to version 3.x we run into an incompatible engine problem.

The CI tests also against version 18 of node, so this should theoretically be fine. https://github.com/florianeckerstorfer/gatsby-plugin-advanced-feed/blob/main/.github/workflows/unit.yml

Ideally this engine check is updated to node 20 (if you support that), but for now I've only made the change I'm relatively confident is fine and supported, but something to look into for the near future I hope.

Node 16 will EOL soon, so people will be upgrading to node 18 sooner or later (:tm:)

```
error @fec/gatsby-plugin-advanced-feed@3.0.1: The engine "node" is incompatible with this module. Expected version ">=14.0.0 <17.0.0". Got "18.16.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
