### PR TITLE
Upgrades for Gatsby 5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -37,7 +37,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -51,4 +51,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v1
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install
-          npm install gatsby@4
+          npm install gatsby@5
       - name: Run tests
         run: npm test
         env:

--- a/__tests__/gatsby-node.test.js
+++ b/__tests__/gatsby-node.test.js
@@ -100,7 +100,9 @@ describe('onPostBuild()', () => {
       expect(feedMock.mock.calls[0][0].feedLinks.json).toBe(
         `${siteMetadata.siteUrl}/feed.json`
       );
-      expect(feedMock.mock.calls[0][0].author.name).toBe(siteMetadata.author.name);
+      expect(feedMock.mock.calls[0][0].author.name).toBe(
+        siteMetadata.author.name
+      );
       expect(feedMock.mock.calls[0][0].author.link).toBe(siteMetadata.siteUrl);
       // By default, email address should be undefined
       // This ensures that authors don't accidentally publish their

--- a/__tests__/gatsby-ssr.test.js
+++ b/__tests__/gatsby-ssr.test.js
@@ -1,5 +1,6 @@
 import { onRenderBody } from '../src/gatsby-ssr';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 beforeAll(() => {
   global.__PATH_PREFIX__ = '';
@@ -26,16 +27,16 @@ describe('onRenderBody', () => {
     const links = setHeadComponents.mock.calls[0][0];
     expect(links.length).toBe(3);
 
-    const rssLink = shallow(links[0]);
-    const atomLink = shallow(links[1]);
-    const jsonLink = shallow(links[2]);
+    const rssLink = render(links[0]).container.querySelector('link');
+    const atomLink = render(links[1]).container.querySelector('link');
+    const jsonLink = render(links[2]).container.querySelector('link');
 
-    expect(rssLink.prop('href')).toBe('/rss.xml');
-    expect(rssLink.prop('type')).toBe('application/rss+xml');
-    expect(atomLink.prop('href')).toBe('/atom.xml');
-    expect(atomLink.prop('type')).toBe('application/atom+xml');
-    expect(jsonLink.prop('href')).toBe('/feed.json');
-    expect(jsonLink.prop('type')).toBe('application/json');
+    expect(rssLink).toHaveAttribute('href', '/rss.xml');
+    expect(rssLink).toHaveAttribute('type', 'application/rss+xml');
+    expect(atomLink).toHaveAttribute('href', '/atom.xml');
+    expect(atomLink).toHaveAttribute('type', 'application/atom+xml');
+    expect(jsonLink).toHaveAttribute('href', '/feed.json');
+    expect(jsonLink).toHaveAttribute('type', 'application/json');
   });
 
   it('should render links in head if pluginOptions.feeds is array', () => {
@@ -55,9 +56,12 @@ describe('onRenderBody', () => {
     onRenderBody({ pathname: '', setHeadComponents }, { feeds: [{ output }] });
 
     const links = setHeadComponents.mock.calls[0][0];
-    expect(shallow(links[0]).prop('href')).toBe('/my-rss.xml');
-    expect(shallow(links[1]).prop('href')).toBe('/my-atom.xml');
-    expect(shallow(links[2]).prop('href')).toBe('/my-feed.json');
+    expect(render(links[0]).container.querySelector('link'))
+      .toHaveAttribute('href', '/my-rss.xml');
+    expect(render(links[1]).container.querySelector('link'))
+      .toHaveAttribute('href', '/my-atom.xml');
+    expect(render(links[2]).container.querySelector('link'))
+      .toHaveAttribute('href', '/my-feed.json');
   });
 
   it('should not prepend slash if pluginOptions.feeds[].output already contains slash', () => {
@@ -65,9 +69,12 @@ describe('onRenderBody', () => {
     onRenderBody({ pathname: '', setHeadComponents }, { feeds: [{ output }] });
 
     const links = setHeadComponents.mock.calls[0][0];
-    expect(shallow(links[0]).prop('href')).toBe('/rss.xml');
-    expect(shallow(links[1]).prop('href')).toBe('/atom.xml');
-    expect(shallow(links[2]).prop('href')).toBe('/feed.json');
+    expect(render(links[0]).container.querySelector('link'))
+      .toHaveAttribute('href', '/rss.xml');
+    expect(render(links[1]).container.querySelector('link'))
+      .toHaveAttribute('href', '/atom.xml');
+    expect(render(links[2]).container.querySelector('link'))
+      .toHaveAttribute('href', '/feed.json');
   });
 
   it('should not render links in head if `createLinkInHead` is `false`', () => {

--- a/__tests__/gatsby-ssr.test.js
+++ b/__tests__/gatsby-ssr.test.js
@@ -56,12 +56,18 @@ describe('onRenderBody', () => {
     onRenderBody({ pathname: '', setHeadComponents }, { feeds: [{ output }] });
 
     const links = setHeadComponents.mock.calls[0][0];
-    expect(render(links[0]).container.querySelector('link'))
-      .toHaveAttribute('href', '/my-rss.xml');
-    expect(render(links[1]).container.querySelector('link'))
-      .toHaveAttribute('href', '/my-atom.xml');
-    expect(render(links[2]).container.querySelector('link'))
-      .toHaveAttribute('href', '/my-feed.json');
+    expect(render(links[0]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/my-rss.xml'
+    );
+    expect(render(links[1]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/my-atom.xml'
+    );
+    expect(render(links[2]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/my-feed.json'
+    );
   });
 
   it('should not prepend slash if pluginOptions.feeds[].output already contains slash', () => {
@@ -69,12 +75,18 @@ describe('onRenderBody', () => {
     onRenderBody({ pathname: '', setHeadComponents }, { feeds: [{ output }] });
 
     const links = setHeadComponents.mock.calls[0][0];
-    expect(render(links[0]).container.querySelector('link'))
-      .toHaveAttribute('href', '/rss.xml');
-    expect(render(links[1]).container.querySelector('link'))
-      .toHaveAttribute('href', '/atom.xml');
-    expect(render(links[2]).container.querySelector('link'))
-      .toHaveAttribute('href', '/feed.json');
+    expect(render(links[0]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/rss.xml'
+    );
+    expect(render(links[1]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/atom.xml'
+    );
+    expect(render(links[2]).container.querySelector('link')).toHaveAttribute(
+      'href',
+      '/feed.json'
+    );
   });
 
   it('should not render links in head if `createLinkInHead` is `false`', () => {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "coverage": "jest --coverage"
   },
   "jest": {
-    "setupFiles": [
-      "./setupTests.js"
-    ]
+    "testEnvironment": "jsdom"
   },
   "private": false,
   "license": "MIT",
@@ -36,26 +34,27 @@
     "url": "https://github.com/florianeckerstorfer/gatsby-plugin-advanced-feed.git"
   },
   "engines": {
-    "node": ">=14.0.0 <17.0.0"
+    "node": ">=18.0.0 <22.0.0"
   },
   "dependencies": {
-    "dayjs": "^1.10.7",
+    "dayjs": "^1.11.10",
     "feed": "^4.2.2"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.16.0",
-    "@babel/cli": "^7.16.0",
-    "@babel/core": "^7.16.0",
-    "babel-eslint": "^10.0.2",
-    "babel-preset-gatsby-package": "^2.0.0",
+    "@babel/cli": "^7.23.0",
+    "@babel/core": "^7.23.2",
+    "@babel/eslint-parser": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.0.0",
+    "babel-preset-gatsby-package": "^3.12.0",
     "cross-env": "^7.0.3",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.6",
-    "jest": "^29.0.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "gatsby": "^4.0.2"
+    "gatsby": "^5.12.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fec/gatsby-plugin-advanced-feed",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Gatsby plugin that generates RSS 2, Atom and JSON feeds for your site.",
   "author": "Florian Eckerstorfer <florian@eckerstorfer.net>",
   "main": "index.js",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,0 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure({ adapter: new Adapter() });


### PR DESCRIPTION
Upgrade and fix test programs to make this plugin installed in Gatsby 5

- Bump dependent packages
  - react: 16 -> 18
  - babel-eslint -> @babel/eslint-parser
  - babel-preset-gatsby-package: 2 -> 3
- Migrate enzyme to @testing-library/react due to enzyme's end of support after React 16
- bump node engine version to current one: v14 ~ 16 -> v18 ~ 21
- upgrade versions of GitHub actions

I have changed the package version number to 3.1.0. But, it would be other numbers, I guess.
